### PR TITLE
Fix normalize-query for utf-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Fixed
 
+- Fixed an issue in `lambdaisland.uri.normalize/normalize-query` which did
+not take into account utf-16 encoding.
+
 ## Changed
 
 # 1.10.79 (2021-10-12 / d90c6a8)

--- a/test/lambdaisland/uri/normalize_test.cljc
+++ b/test/lambdaisland/uri/normalize_test.cljc
@@ -8,7 +8,8 @@
     "http://example.com/a b c"     "http://example.com/a%20b%20c"
     "http://example.com/a%20b%20c" "http://example.com/a%20b%20c"
     "/𝍖"                          "/%F0%9D%8D%96"
-    "http://foo.bar/?x=%20" "http://foo.bar/?x=%20")
+    "http://foo.bar/?x=%20" "http://foo.bar/?x=%20"
+    "https://example.com?text=You are welcome 🙂" "https://example.com?text=You%20are%20welcome%20%F0%9F%99%82" )
 
   (are [x y] (= (-> x n/normalize str) y)
     (uri/map->URI {:query "x=y"}) "?x=y"
@@ -17,8 +18,8 @@
     (uri/map->URI {:query "foo=b%61r"}) "?foo=bar"
     (uri/map->URI {:query "foo=bar%3Dbaz"}) "?foo=bar%3Dbaz"
     (uri/map->URI {:query "foo=%20%2B%26xxx%3D123"}) "?foo=%20%2B%26xxx%3D123"
+    (uri/map->URI {:query "text=You are welcome 🙂"}) "?text=You%20are%20welcome%20%F0%9F%99%82"
     ))
-
 
 (deftest normalize-path-test
   (are [x y] (= (n/normalize-path x) y)


### PR DESCRIPTION
Hi @Gaiwan, 

Something like 
```clj
(require '[lambdaisland.uri :as uri])
(require '[lambdaisland.uri.normalize :as n])

(n/normalize (uri/uri "https://twitter.com/intent/tweet?text=You are welcome 🙂&url=https://lambdaisland.com"))
```
will currently fail as `normalize-query` currently does not take utf-16 chars into account.

The patch only fixes the `normalize-query` part, something like 
```clj
(n/char-seq (subs "🙂" 0 1))
```
will still fail. I wasn't quite sure how you want to deal with edge cases like these.

- [x] the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- [ ] ~the README and other documentation~
- [x] the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

I ran `bin/kaocha` once.

