### PR TITLE
Prevent lambdaisland.uri.normalize/char-seq stack overflow

### DIFF
--- a/src/lambdaisland/uri/normalize.cljc
+++ b/src/lambdaisland/uri/normalize.cljc
@@ -49,12 +49,16 @@
   ([str]
    (char-seq str 0))
   ([str offset]
-   (if (>= offset (str-len str))
-     ()
-     (let [code (char-code-at str offset)
-           width (if (high-surrogate? code) 2 1)]
-       (cons (subs str offset (+ offset width))
-             (char-seq str (+ offset width)))))))
+   (loop [offset offset
+          res []]
+     (if (>= offset (str-len str))
+       res
+       (let [code (char-code-at str offset)
+             width (if (high-surrogate? code) 2 1)
+             next-offset (+ offset width)
+             cur-char (subs str offset next-offset)]
+         (recur next-offset
+                (conj res cur-char)))))))
 
 (defn percent-encode
   "Convert characters in their percent encoded form. e.g.

--- a/test/lambdaisland/uri/normalize_test.cljc
+++ b/test/lambdaisland/uri/normalize_test.cljc
@@ -21,6 +21,16 @@
     (uri/map->URI {:query "text=You are welcome 🙂"}) "?text=You%20are%20welcome%20%F0%9F%99%82"
     ))
 
+(deftest char-seq-test
+  (let [long-string (->> "s"
+                         ;; Long enough to trigger StackOverflow in non-tail recursive cases.
+                         (repeat 5000)
+                         (apply str))
+        long-string-len (count long-string)
+        cs (n/char-seq long-string)]
+    (is (= long-string-len (count cs)))
+    (is (every? #{"s"} cs))))
+
 (deftest normalize-path-test
   (are [x y] (= (n/normalize-path x) y)
     "/abc" "/abc"


### PR DESCRIPTION
- Impl with tail recursion instead

There are certain real-world scenarios encountered where a query param value may be close to the limit of default stack sizes are on the JVM (I'm not sure if the limits are higher or less on the avg JS VMs).

The situation I encountered this was for creating SAMLResponse query values in particular, which are encodings of an xml message. This is a popular authentication framework.

I have a test case testing the bare minimum that should fail on default JVM stack sizes.

`char-seq` notably is named "seq", which doesn't commit to laziness exactly, however, it was formerly lazy. The approach I'm taking now instead is an eager tail-recursive implementation of the same semantics.