### PR TITLE
readme: add babashka compatible badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!-- badges -->
 [![CircleCI](https://circleci.com/gh/lambdaisland/uri.svg?style=svg)](https://circleci.com/gh/lambdaisland/uri) [![cljdoc badge](https://cljdoc.org/badge/lambdaisland/uri)](https://cljdoc.org/d/lambdaisland/uri) [![Clojars Project](https://img.shields.io/clojars/v/lambdaisland/uri.svg)](https://clojars.org/lambdaisland/uri)
+[![bb compatible](https://raw.githubusercontent.com/babashka/babashka/master/logo/badge.svg)](https://babashka.org)
 <!-- /badges -->
 
 A pure Clojure/ClojureScript URI library.


### PR DESCRIPTION
It's wonderful that uri works as a babashka dependency. And there is now a badge to let folks know, at a glance, that this is the case!


