### PR TITLE
Fix version incompatibility.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
             chmod +x install
-            sudo ./install
+            ./install
             bb test:bb
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,11 @@ jobs:
     steps:
       - checkout
       - run:
-          curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
-          chmod +x install
-          sudo ./install
-          bb test:bb
+          command: |
+            curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
+            chmod +x install
+            sudo ./install
+            bb test:bb
 
 workflows:
   kaocha_test:

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
   {:extra-paths ["test"]
    :extra-deps
    {org.clojure/clojurescript     {:mvn/version "1.10.597"}
-    lambdaisland/kaocha           {:mvn/version "RELEASE"}
-    com.lambdaisland/kaocha-cljs      {:mvn/version "1.0.113"}
+    lambdaisland/kaocha           {:mvn/version "1.70.1086"}
+    com.lambdaisland/kaocha-cljs      {:mvn/version "1.4.130"}
     lambdaisland/kaocha-junit-xml {:mvn/version "RELEASE"}
     org.clojure/test.check        {:mvn/version "1.0.0"}}}}}


### PR DESCRIPTION
After upgrading deep-diff in kaocha and kaocha-cljs, mixing an old version of one with a new version of the other causes a dependency error. This is why tests have been failing.

