### PR TITLE
Allow query-string keys without values to map->query-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Add `nillable?` boolean option to `map->query-string` to support query-string keys without values
+
 ## Fixed
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ project.clj
 ## Usage
 
 ``` clojure
-(require '[lambdaisland.uri :refer [uri join]])
+(require '[lambdaisland.uri :refer [uri join map->query-string parse]])
 
 
 ;; uri :: String -> lambdaisland.uri.URI
@@ -98,6 +98,23 @@ project.clj
 ;; URI implements IFn for keyword based lookup, so it's fully
 ;; interface-compatible with Clojure maps.
 (:path (uri "http://example.com/foo/bar"))
+
+;; Extracting query-params from a query-string
+(query-string->map "foo=bar")
+=> {:foo "bar"}
+;; and back
+(map->query-string {:foo "bar"})
+=> "foo=bar"
+
+;; Query-string keys without values can be added using `nillable?` option (clojure example)
+(import java.util.concurrent.ThreadLocalRandom)
+(-> (parse "http://example.com")
+    (update :query #(-> %
+                        (merge {(->> (ThreadLocalRandom/current) .nextLong (format "%016x")) nil})
+                        (map->query-string {:nillable? true})))
+    uri
+    str)
+=> "http://example.com?9dc63f4f67ef9ba0"
 
 ;; Instances of URI are printed with a #lambdaisland/uri reader tag. To read
 ;; them back from EDN, use the provided readers.

--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -214,7 +214,12 @@
   "Convert a map into a query string, consisting of key=value pairs separated by
   `&`. The result is percent-encoded so it is always safe to use. Keys can be
   strings or keywords. If values are collections then this results in multiple
-  entries for the same key. `nil` values are ignored. Values are stringified."
+  entries for the same key. `nil` values are ignored. Values are stringified.
+
+  Takes the following options:
+
+  - `nillable?` whether to return query param key alone when value is nil,
+    defaults to `false` (empty returned)"
   ([m]
    (map->query-string m nil))
   ([m {:keys [nillable?]

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -186,3 +186,9 @@
                   uri/query-string->map)]
       (or (and (empty? q) (empty? res)) ;; (= nil {})
           (= q res)))))
+
+(deftest map->query-string-test
+  (is (= "foo" (uri/map->query-string {:foo nil} {:nillable? true})))
+  (is (= "foo&bar" (uri/map->query-string {:foo nil :bar nil} {:nillable? true})))
+  (is (= "foo&bar&foobar=1" (uri/map->query-string {:foo nil :bar nil :foobar 1} {:nillable? true})))
+  (is (= "" (uri/map->query-string {:foo nil} {:nillable? false}))))


### PR DESCRIPTION
This solves my problem I'm running into when we want to add query-string keys that aren't accompanied with values (which should be RFC-compliant).