### PR TITLE
Provide custom target data structure for query-string->map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Adds `:into` option to define custom `clojure.lang.IPersistentMap` target data structure for `lambdaisland.uri/query-string->map`
+
 ## Fixed
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ project.clj
 ;; interface-compatible with Clojure maps.
 (:path (uri "http://example.com/foo/bar"))
 
+;; Provide custom ordering for query-map
+;; clj -Sdeps '{:deps {org.flatland/ordered {:mvn/version "1.5.7"}}}'
+(require '[lambdaisland.uri :refer [query-map]]
+         '[flatland.ordered.map :refer [ordered-map]])
+(keys (query-map "http://example.com?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9"
+                 {:into (ordered-map)}))
+=> (:a :b :c :d :e :f :g :h :i)
+
 ;; Instances of URI are printed with a #lambdaisland/uri reader tag. To read
 ;; them back from EDN, use the provided readers.
 (require '[clojure.edn :as edn])

--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -141,6 +141,8 @@
   - `:keywordize?` whether to turn return keys as keywords. Defaults to `true`.
   - `:multikeys` how to handle the same key occuring multiple times, defaults to
     `:duplicates`
+  - `:into` provide `clojure.lang.IPersistentMap` to define target data structure,
+    defaults to `clojure.lang.PersistentHashMap`
 
   The possible values for `:multikeys` are
 
@@ -152,9 +154,10 @@
     string otherwise"
   ([q]
    (query-string->map q nil))
-  ([q {:keys [multikeys keywordize?]
+  ([q {:keys [multikeys keywordize? into]
        :or {multikeys :duplicates
-            keywordize? true}}]
+            keywordize? true
+            into {}}}]
    (when (not (str/blank? q))
      (->> (str/split q #"&")
           (map decode-param-pair)
@@ -174,7 +177,7 @@
                      (update m k conj v)
                      (assoc m k [(m k) v]))
                    (assoc m k v)))))
-           {})))))
+           into)))))
 
 (defn query-map
   "Return the query section of a URI as a map. Will coerce its argument

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -139,7 +139,11 @@
          (uri/query-map "?foo=bar&id=2" {:multikeys :always})))
 
   (is (= {:foo " +&xxx=123"}
-         (uri/query-map "?foo=%20%2B%26xxx%3D123"))))
+         (uri/query-map "?foo=%20%2B%26xxx%3D123")))
+
+  (is (= [:a :b :c :d :e :f :g :h :i]
+         (keys (uri/query-map "http://example.com?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9"
+                              {:into (sorted-map)})))))
 
 (deftest assoc-query-test
   (is (= (uri/uri "http://example.com?foo=baq&aaa=bbb&hello=world")


### PR DESCRIPTION
This is a minimal approach to fix an ordering issue which query-string parsing will experience when there are more than 8 query-string arguments.

Fixes #35 .