### PR TITLE
fix using :domain key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ supported. As an alternative to `clojure.core/str` you can use
 ``` clojure
 ;; clojure / clojurescript
 (str uri) ;; "https://example.com"
-(uri :domain) ;; "example.com"
+(uri :host) ;; "example.com"
 
 ;; bb
 (str uri) ;; "{:scheme "https", :domain "example.com", :path ...}"
-(uri :domain) ;; nil
+(uri :host) ;; nil
 
 (uri/uri-str uri) ;; "https://example.com"
-(:domain uri) ;; "example.com"
-(get uri :domain) ;; "example.com"
+(:host uri) ;; "example.com"
+(get uri :host) ;; "example.com"
 ```
 
 ## Similar projects


### PR DESCRIPTION
from the issue #34, I made this modification. 

However, in my experiment with Babashka version  `v0.9.161`. It works quite differently from the README's example, but I do not how to explain it. 

`bb.edn`
```
{:paths ["src"]
 :deps { lambdaisland/uri {:mvn/version "1.13.95"}}}
```

`li.clj`
```
#!/usr/bin/env bb
(ns li
  (:require [lambdaisland.uri :as liu]))

(def u (liu/uri "https://example.com"))

(str u) ;;=> "https://example.com"
(liu/uri-str u) ;;=> "https://example.com"

(:host u) ;;=> "example.com"
(get u :host) ;;=> "example.com"

(u :host) ;;=> ; (err) : sci.impl.records.SciRecord cannot be cast to clojure.lang.IFn
```

Fixes #34