### PR TITLE
Add support for "=" within a query parameter pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Do not truncate value of a query parameter pain when it contains a nested `=`   
+
 ## Changed
 
 # 1.15.125 (2023-03-30 / 5550226)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-- Do not truncate value of a query parameter pain when it contains a nested `=`   
+- Do not truncate value of a query parameter pair when contains nested `=` characters   
 
 ## Changed
 

--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -130,7 +130,7 @@
 ;; Query strings
 
 (defn- decode-param-pair [param]
-  (let [[k v] (str/split param #"=")]
+  (let [[k v] (str/split param #"=" 2)]
     [(if k (normalize/percent-decode k) "")
      (if v (normalize/percent-decode (str/replace v #"\+" " ")) "")]))
 

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -139,6 +139,9 @@
   (is (= {:foo " +&xxx=123"}
          (uri/query-map "?foo=%20%2B%26xxx%3D123")))
 
+  (is (= {:foo "aaa=bbb"}
+         (uri/query-map "?foo=aaa=bbb")))
+
   (is (= [:a :b :c :d :e :f :g :h :i]
          (keys (uri/query-map "http://example.com?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9"
                               {:into (sorted-map)})))))


### PR DESCRIPTION
I am parsing complex queries which may have the '=' character.

For example:

```
http://snomed.info/sct?fhir_vs=ecl/<<50043002:<<263502005=<<19939008
```

This does not parse correctly as the current handling of `decode-param-pair` splits against *all* '=' in the pair, whereas this PR splits only on the first '='.