### PR TITLE
Trim uri before parse

### DIFF
--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -54,7 +54,8 @@
 (defn parse
   "Parse a URI string into a lambadisland.uri.URI record."
   [uri]
-  (let [[scheme authority path query fragment] (match-uri uri)]
+  (let [trimmed-uri (str/trim uri)
+        [scheme authority path query fragment] (match-uri trimmed-uri)]
     (if authority
       (let [[user password host port] (match-authority authority)]
         (URI. scheme user password host port path query fragment))

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -21,7 +21,10 @@
       (uri/->URI nil nil nil nil nil "relative/path" nil nil)
 
       "http://example.com"
-      (uri/->URI "http" nil nil "example.com" nil nil nil nil))))
+      (uri/->URI "http" nil nil "example.com" nil nil nil nil)
+
+      "  http://example.com/path  "
+      (uri/->URI "http" nil nil "example.com" nil "/path" nil nil))))
 
 (deftest joining
   (are [x y] (= (uri/parse y) (apply uri/join (map uri/parse x)))


### PR DESCRIPTION
First of all, thx for you amazing and very helpful library. 

About PR. I'm not sure the suggested argument pre-processing is appropriate. But I think the resulting parsing results can be misleading.

```clojure
(into {} (uri/parse "  https://example.com/path  "))
=>
{:scheme "  https",
 :user nil,
 :password nil,
 :host "example.com",
 :port nil,
 :path "/path  ",
 :query nil,
 :fragment nil}
```