### PR TITLE
Return into if blank input in query-map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ node_modules
 .cpcache
 package-lock.json
 .store
+.idea/
+.clj-kondo/

--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -158,7 +158,8 @@
        :or {multikeys :duplicates
             keywordize? true
             into {}}}]
-   (when (not (str/blank? q))
+   (if (str/blank? q)
+     into
      (->> (str/split q #"&")
           (map decode-param-pair)
           (reduce

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -144,7 +144,10 @@
 
   (is (= [:a :b :c :d :e :f :g :h :i]
          (keys (uri/query-map "http://example.com?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9"
-                              {:into (sorted-map)})))))
+                              {:into (sorted-map)}))))
+
+  (is (= {}
+         (uri/query-map "http://example.com/path"))))
 
 (deftest assoc-query-test
   (is (= (uri/uri "http://example.com?foo=baq&aaa=bbb&hello=world")


### PR DESCRIPTION
Hello, really appreciate you work. I suggest returning an empty map instead of null for the function.

In my case, it is necessary to add UTM tags to the URL with minimal changes. Source URLs come from clients with very different quality, some, for example, are sensitive to the order of arguments(sic!). Sometimes there are URLs without any parameters at all, and then the function returns nil, which does not meet my expectations from a function like query-map  in its name. I expect empty-map(or into) if no query-param exist in passed url.

For example write fn 

```clojure
(defn merge-params
  [^String uri-string params]
  (let [uri (uri/parse (prepare-uri-string uri-string))
        ordered-query-map (uri/query-map uri {:into (ordered-map)})
        sorted-params (sort params)
        result-query (into ordered-query-map sorted-params)]
    (-> uri
        (assoc :query (uri/map->query-string result-query))
        (str))))
```

Because of behaviour described above, when calling a function I get an unexpected result(incorrect order)
```clojure
(merge-params "https://example.com/path" {:a 1 :b 2})
=> "https://example.com/path?b=2&a=1"
```

Because of inner behavior that boils down to the following
```clojure
(into nil [[:a 1] [:b 2]])
=> ([:b 2] [:a 1])
```