### PR TITLE
More conservative into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,21 @@
 
 ## Changed
 
-# 1.17.141 (2024-01-23 / 96249d9)
-
 - `query-map` / `query-string->map`: when called with an `:into` collection, and
   no query params are present, then return the `:into` collection, rather than
   `nil`. If no explicit `:into` collection is provided, then retain the existing
   behavior of returning `nil`.
 
-# 1.16.134 (2023-10-10 / c0f16d8)
+# 1.17.141 (2024-01-23 / 96249d9)
 
 ## Added
 
 - Added functions for dealing with query strings as positional collections:
   `query-string->seq`, `seq->query-string`.
+
+## Changed
+
+- `query-map` : return `:into` value on blank input
 
 # 1.16.134 (2023-10-10 / c0f16d8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `query-map` / `query-string->map`: when called with an `:into` collection, and
   no query params are present, then return the `:into` collection, rather than
   `nil`. If no explicit `:into` collection is provided, then retain the existing
-  behavior of returning `nil`.
+  behavior of returning `nil` on blank input.
 
 # 1.17.141 (2024-01-23 / 96249d9)
 
@@ -16,7 +16,7 @@
 
 ## Changed
 
-- `query-map` : return `:into` value on blank input
+- `query-map`/`query-string->map` : return `:into` value on blank input
 
 # 1.16.134 (2023-10-10 / c0f16d8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Unreleased
 
-## Added
-
-## Fixed
-
 ## Changed
 
 # 1.17.141 (2024-01-23 / 96249d9)
+
+- `query-map` / `query-string->map`: when called with an `:into` collection, and
+  no query params are present, then return the `:into` collection, rather than
+  `nil`. If no explicit `:into` collection is provided, then retain the existing
+  behavior of returning `nil`.
+
+# 1.16.134 (2023-10-10 / c0f16d8)
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,9 @@
 
 # 1.16.134 (2023-10-10 / c0f16d8)
 
-## Added
-
 ## Fixed
 
-- Do not truncate value of a query parameter pair when contains nested `=` characters   
-
-## Changed
+- Do not truncate value of a query parameter pair when contains nested `=` characters
 
 # 1.15.125 (2023-03-30 / 5550226)
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,6 @@
 {:deps
  {lambdaisland/open-source {:git/url "https://github.com/lambdaisland/open-source"
-                            :git/sha "99b33741ea499e1c58e5ab6c2b785ba18eca84d2"}
+                            :git/sha "7ce125cbd14888590742da7ab3b6be9bba46fc7a"}
   current/project {:local/root "."}}
 
  :tasks

--- a/deps.edn
+++ b/deps.edn
@@ -6,8 +6,8 @@
   :test
   {:extra-paths ["test"]
    :extra-deps
-   {org.clojure/clojurescript     {:mvn/version "1.11.60"}
-    lambdaisland/kaocha           {:mvn/version "1.81.1290"}
-    com.lambdaisland/kaocha-cljs      {:mvn/version "1.4.130"}
-    lambdaisland/kaocha-junit-xml {:mvn/version "RELEASE"}
+   {org.clojure/clojurescript     {:mvn/version "1.11.121"}
+    lambdaisland/kaocha           {:mvn/version "1.87.1366"}
+    com.lambdaisland/kaocha-cljs  {:mvn/version "1.5.154"}
+    lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
     org.clojure/test.check        {:mvn/version "1.1.1"}}}}}

--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -156,8 +156,7 @@
    (query-string->map q nil))
   ([q {:keys [multikeys keywordize? into]
        :or {multikeys :duplicates
-            keywordize? true
-            into {}}}]
+            keywordize? true}}]
    (if (str/blank? q)
      into
      (->> (str/split q #"&")
@@ -178,7 +177,7 @@
                      (update m k conj v)
                      (assoc m k [(m k) v]))
                    (assoc m k v)))))
-           into)))))
+           (or into {}))))))
 
 (defn query-string->seq
   "Parse a query string, consisting of key=value pairs, separated by `\"&\"`.

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -146,8 +146,7 @@
          (keys (uri/query-map "http://example.com?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9"
                               {:into (sorted-map)}))))
 
-  (is (= {}
-         (uri/query-map "http://example.com/path"))))
+  (is (= nil (uri/query-map "http://example.com/path"))))
 
 (deftest assoc-query-test
   (is (= (uri/uri "http://example.com?foo=baq&aaa=bbb&hello=world")


### PR DESCRIPTION
Revert to the old behavior for query-map if no `:into` is specified

The previous change constitutes a breaking change, existing code might rely on
the behavior of returning `nil`, e.g. in an `if-let`.

```clj
(if-let [m (query-map uri)] ,,,)
```

However, when an explicit `:into` is provided, it is reasonable to assume that
you expect something of the same type to be returned. E.g. when calling
`(query-map uri {:into (sorted-map)})`, it is reasonable to expect that the
result is a sorted-map.

So this is a compromise, where we return `:into` if it is explicitly specified,
or `nil` if not.
