### PR TITLE
query-string->coll and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Added
 
+- Added functions for dealing with query strings as positional collections: `query-string->seq`,
+  `seq->query-string`.
+
 ## Fixed
 
 ## Changed

--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -180,6 +180,16 @@
                    (assoc m k v)))))
            into)))))
 
+(defn query-string->seq
+  "Parse a query string, consisting of key=value pairs, separated by \"&\".
+   Return vector of positional [key value] tuples. Keys and values are strings.
+   Returns empty vector if q is empty string or nil."
+  [q]
+  (if (str/blank? q)
+    []
+    (->> (str/split q #"&")
+         (mapv decode-param-pair))))
+
 (defn query-map
   "Return the query section of a URI as a map. Will coerce its argument
   with [[uri]]. Takes an options map, see [[query-string->map]] for options."
@@ -232,6 +242,17 @@
                      [(encode-param-pair k v)])))
          (interpose "&")
          (apply str))))
+
+(defn seq->query-string
+  "Convert a positional collection of [key value] tuples into a query string, consisting of key=value pairs
+   separated by `&`. The result is percent-encoded, so it is always safe to use.
+   Keys can be strings or keywords. Tuple with `nil` value adds entry like `key=` to query string.
+   Values are stringified."
+  [coll]
+  (some->> (seq coll)
+           (map (fn [[k v]] (encode-param-pair k v)))
+           (interpose "&")
+           (apply str)))
 
 (defn assoc-query*
   "Add additional query parameters to a URI. Takes a URI (or coercible to URI) and

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -180,6 +180,22 @@
              (uri/assoc-query* {:a "a b"})
              uri/query-map))))
 
+(deftest query-string->seq-test
+  (are [query-string expected]
+    (= expected (uri/query-string->seq query-string))
+    nil []
+    "" []
+    "a=1&b=2&a=3" [["a" "1"] ["b" "2"] ["a" "3"]]
+    "a=1&b=" [["a" "1"] ["b" ""]]))
+
+(deftest seq->query-string-test
+  (are [seq-of-tuples expected]
+    (= expected (uri/seq->query-string seq-of-tuples))
+    nil nil
+    [] nil
+    [["a" "1"] ["b" "2"] ["a" "3"]] "a=1&b=2&a=3"
+    [["a" "1"] ["b" ""]] "a=1&b="))
+
 (deftest uri-predicate-test
   (is (true? (uri/uri? (uri/uri "/foo")))))
 


### PR DESCRIPTION
After the discussion in #47, I realized that my proposal was probably too complex and it would be better to break it down into several parts. This PR assumes a basic implementation without additionally features like into and keywordizе. Only the functionality itself, without DRY optimizations, etc.