### PR TITLE
Change query-string->seq to query-string->vec

### DIFF
--- a/src/lambdaisland/uri.cljc
+++ b/src/lambdaisland/uri.cljc
@@ -180,14 +180,14 @@
                    (assoc m k v)))))
            into)))))
 
-(defn query-string->seq
-  "Parse a query string, consisting of key=value pairs, separated by `\"&\"`.
-   Return a seq of `[key value]` pairs, in the exact order they occur in the
-  query string. Keys and values are strings. Returns `nil` if `q` is blank or
-  `nil`."
+(defn query-string->vec
+  "Parse a query string, consisting of key=value pairs, separated by \"&\".
+   Return vector of positional [key value] pairs, in the exact order they occur in the
+   query string. Keys and values are strings. Returns empty vector if q is empty string or nil."
   [q]
-  (when-not (str/blank? q)
-    (map decode-param-pair (str/split q #"&"))))
+  (if (str/blank? q)
+    []
+    (mapv decode-param-pair (str/split q #"&"))))
 
 (defn query-map
   "Return the query section of a URI as a map. Will coerce its argument

--- a/test/lambdaisland/uri_test.cljc
+++ b/test/lambdaisland/uri_test.cljc
@@ -180,11 +180,11 @@
              (uri/assoc-query* {:a "a b"})
              uri/query-map))))
 
-(deftest query-string->seq-test
+(deftest query-string->vec-test
   (are [query-string expected]
-    (= expected (uri/query-string->seq query-string))
-    nil nil
-    "" nil
+    (= expected (uri/query-string->vec query-string))
+    nil []
+    "" []
     "a=1&b=2&a=3" [["a" "1"] ["b" "2"] ["a" "3"]]
     "a=1&b=" [["a" "1"] ["b" ""]]))
 
@@ -195,6 +195,12 @@
     [] ""
     [["a" "1"] ["b" "2"] ["a" "3"]] "a=1&b=2&a=3"
     [["a" "1"] ["b" ""]] "a=1&b="))
+
+(deftest query-string-add-param-test
+  (let [original-query (uri/query-string->vec "c=3&d=4")
+        params-to-append (sort {:b 2 :a 1}) ;; ([:a 1] [:b 2])
+        modified-query (into original-query params-to-append)]
+    (is (= "c=3&d=4&a=1&b=2" (uri/seq->query-string modified-query)))))
 
 (deftest uri-predicate-test
   (is (true? (uri/uri? (uri/uri "/foo")))))


### PR DESCRIPTION
I started testing #51 functionality and discovered some non-desired behavior. I've added an additional test case that shows the problem and also show example of usage query-string->seq fns.

We once discussed in other PR whether I had any reasons why a vector should be returned from query-string->seq and now I think answer is yes. I also renamed it to query-string->vec. 

Non-desired behavior can reproduce with next steps. Change `mapv` to `map` in the `query-string->vec` function. After that new test case will return “b=2&a=1&c=3&d=4” instead of “c=3&d=4&a=1&b=2” with `mapv`, which is completely fail idea of usage new functions. 

Reason of behaviour the same like in `conj` and `cons` fns.

1. To avoid non-desired behaviour, I also again suggest returning a vector instead of a nil. `(into nil ...)` leads to unobvious results. I make it return nil to look the same as existing `query-string->map` fn. But now i think it's mislead user. If we have to return maybe change fn name to `query-string->vec-or-nil`. But personally i prefer `query-string->vec` and return an empty vector if the user passed a string without parameters
2. I don't like what pair functions are called `query-string->vec` and `seq->query-string` but it reflects the meaning and I couldn’t figure out how to express it better